### PR TITLE
Update SocketAppender.cs

### DIFF
--- a/src/Log4netSocketAppender/Log4netSocketAppender/SocketAppender.cs
+++ b/src/Log4netSocketAppender/Log4netSocketAppender/SocketAppender.cs
@@ -72,11 +72,25 @@ namespace log4net.Appender
 
             if (_socket.Connected)
             {
-                rendered = RenderLoggingEvent(loggingEvent);
+                rendered = RenderLoggingEvent(loggingEvent);                
 
                 var msg = Encoding.UTF8.GetBytes(rendered);
-
-                var bytesSent = _socket.Send(msg);
+                try
+                {
+                    var bytesSent = _socket.Send(msg);
+                }
+                catch (ArgumentNullException argumentNullException)
+                {
+                    Console.WriteLine("ArgumentNullException : {0}", argumentNullException);
+                }
+                catch (SocketException socketException)
+                {
+                    Console.WriteLine("SocketException : {0}", socketException);
+                }
+                catch (Exception exception)
+                {
+                    Console.WriteLine("Unexpected exception : {0}", exception);
+                }
 
                 if (DebugMode)
                 {

--- a/src/Log4netSocketAppender/Log4netSocketAppender/SocketAppender.cs
+++ b/src/Log4netSocketAppender/Log4netSocketAppender/SocketAppender.cs
@@ -78,6 +78,10 @@ namespace log4net.Appender
                 try
                 {
                     var bytesSent = _socket.Send(msg);
+                    if (DebugMode)
+                    {
+                        Console.WriteLine("- Bytes sent: " + bytesSent);
+                    }
                 }
                 catch (ArgumentNullException argumentNullException)
                 {
@@ -90,11 +94,6 @@ namespace log4net.Appender
                 catch (Exception exception)
                 {
                     Console.WriteLine("Unexpected exception : {0}", exception);
-                }
-
-                if (DebugMode)
-                {
-                    Console.WriteLine("- Bytes sent: " + bytesSent);
                 }
             }
             else


### PR DESCRIPTION
This will prevent of throwing exceptions when socket connection lost after connection.

System.Net.Sockets.SocketException
  HResult=0x80004005
  Message=An established connection was aborted by the software in your host machine
  Source=System
  StackTrace:
   at System.Net.Sockets.Socket.Send(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags)
   at log4net.Appender.SocketAppender.AppendLog(LoggingEvent loggingEvent)
   at log4net.Appender.SocketAppender.<>c__DisplayClass1.<Append>b__0(Object state)
   at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()